### PR TITLE
Update apps.py to avoid warning.

### DIFF
--- a/solution/dog_shelters/apps.py
+++ b/solution/dog_shelters/apps.py
@@ -2,4 +2,5 @@ from django.apps import AppConfig
 
 
 class DogSheltersConfig(AppConfig):
+    default_auto_field = 'django.db.models.BigAutoField'    
     name = 'dog_shelters'

--- a/starter/dog_shelters/apps.py
+++ b/starter/dog_shelters/apps.py
@@ -2,4 +2,5 @@ from django.apps import AppConfig
 
 
 class DogSheltersConfig(AppConfig):
+    default_auto_field = 'django.db.models.BigAutoField'    
     name = 'dog_shelters'


### PR DESCRIPTION
More info: https://dev.to/weplayinternet/upgrading-to-django-3-2-and-fixing-defaultautofield-warnings-518n

The code works without this change but puts up warnings that may confuse users and distract from learn modules that use this repo.